### PR TITLE
Info panel shows on Firefox

### DIFF
--- a/browsers/firefox/data/info-panel.html
+++ b/browsers/firefox/data/info-panel.html
@@ -1,0 +1,1 @@
+../../info-panel.html

--- a/browsers/firefox/lib/main.js
+++ b/browsers/firefox/lib/main.js
@@ -2,7 +2,7 @@ var pageMod = require("sdk/page-mod");
 
 var self = require("sdk/self");
 
-pageMod.PageMod({
+var pageModder = pageMod.PageMod({
     include: "*.facebook.com",
     contentStyleFile: self.data.url("eradicate.css"),
     contentScriptFile: [self.data.url("jquery.js"), self.data.url("eradicate.js")],
@@ -10,5 +10,13 @@ pageMod.PageMod({
         urls: {
             'info-panel.html': self.data.url('info-panel.html')
         }
-    }
+    },
+    onAttach: startListening
 });
+
+function startListening(worker) {
+  worker.port.on('requestUrl', function(url) {
+    console.log("Received request");
+    worker.port.emit(url, self.data.load(url));
+  });
+}

--- a/eradicate.js
+++ b/eradicate.js
@@ -167,11 +167,25 @@ var extensionURL = function(relativeURL){
 fbLink = $("<a href='javascript:;'>News Feed Eradicator :)</a>")
     .addClass('nfe-info-link')
     .on('click', function(){
-        infoPanel.load(extensionURL("info-panel.html"),
-            function(){
-                $('.nfe-close-button').on('click', hideInfoPanel);
-            });
-        infoPanel.show();
+      var handleClose = function() {
+        $('.nfe-close-button').on('click', hideInfoPanel);
+      };
+      var url = 'info-panel.html';
+
+      if (window.chrome !== undefined) {
+        // Chrome extension
+        infoPanel.load(chrome.extension.getURL(url),
+                       handleClose);
+      } else {
+        // Firefox extension
+        self.port.emit('requestUrl', url);
+        self.port.once(url, function(data) {
+          console.log("Received data for ", url);
+          infoPanel.html(data);
+          handleClose();
+        });
+      }
+      infoPanel.show();
     })
 	.appendTo(quoteDiv);
 


### PR DESCRIPTION
Fixes the info panel not showing issue in Firefox - turns out you can't pass `resource://` URIs to jQuery, which is why the `.load()` call was not working.

Please double check the info-panel.html symlink - I'm on Windows so cygwin/cygwin-git may have messed something up.
