### PR TITLE
Fixed overlapping quote style issue

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -10,7 +10,7 @@
 	border-left: 4px solid #99f;
 	margin-left: 15px;
 	padding-left: 15px;
-	width: 90%;
+	width: 87.5%;
 }
 
 .nfe-info-panel p


### PR DESCRIPTION
Minor changes to eradicate.css file to stop quote overlapping with options button, fixed for the current issues and should be fixed for all future quotes. 

<img width="509" alt="screen shot 2016-05-28 at 10 48 29 pm" src="https://cloud.githubusercontent.com/assets/11954332/15627427/f97007ec-2526-11e6-85d0-79d65dfbd2d4.png">
<img width="513" alt="screen shot 2016-05-28 at 10 48 12 pm" src="https://cloud.githubusercontent.com/assets/11954332/15627428/f999163c-2526-11e6-98c5-c8e02655b0d0.png">
