### PR TITLE
Remove gaming pagelet

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -235,7 +235,6 @@ div.ego_column,
 #pagelet_trending_tags_and_topics,
 #stories_pagelet_rhc,
 #fb_stories_card_root,
-#pagelet_games_rhc,
 #pagelet_gaming_destination_rhc,
 #pagelet_canvas_nav_content {
 	opacity: 0 !important;

--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -236,6 +236,7 @@ div.ego_column,
 #stories_pagelet_rhc,
 #fb_stories_card_root,
 #pagelet_games_rhc,
+#pagelet_gaming_destination_rhc,
 #pagelet_canvas_nav_content {
 	opacity: 0 !important;
 	pointer-events: none !important;

--- a/src/lib/remove-news-feed.ts
+++ b/src/lib/remove-news-feed.ts
@@ -5,6 +5,7 @@ const elementsToRemove =
 	'.ticker_stream,' +
 	'.ego_column,' +
 	'#pagelet_games_rhc,' +
+        '#pagelet_gaming_destination_rhc,' +
 	'#stories_pagelet_rhc,' +
 	'#fb_stories_card_root,' +
 	'#pagelet_trending_tags_and_topics,' +

--- a/src/lib/remove-news-feed.ts
+++ b/src/lib/remove-news-feed.ts
@@ -4,7 +4,6 @@
 const elementsToRemove =
 	'.ticker_stream,' +
 	'.ego_column,' +
-	'#pagelet_games_rhc,' +
         '#pagelet_gaming_destination_rhc,' +
 	'#stories_pagelet_rhc,' +
 	'#fb_stories_card_root,' +


### PR DESCRIPTION
Addressing #72, updating the id of the gaming pagelet from `#pagelet_games_rhc` to `#pagelet_games_destination_rhc`.

I have split this into two commits in-case there are still situations where the old rule for removing `#pagelet_games_rhc`.  These can be squashed if the old name has been completely replaced.