### PR TITLE
add text-align left to display well in rtl browser

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -9,6 +9,7 @@
 	margin-left: 15px;
 	padding-left: 15px;
 	width: 87.5%;
+	text-align: left;
 }
 
 .nfe-info-panel p {


### PR DESCRIPTION
I added this style to support RTL browsers, this is how it looks in my browser before this change:
![image](https://user-images.githubusercontent.com/1475778/72208635-bc381500-34ad-11ea-803a-47f16e075d3d.png)

And after:
![image](https://user-images.githubusercontent.com/1475778/72208643-cd812180-34ad-11ea-916d-b534a610d945.png)
