### PR TITLE
Add linkedin feed eradicator

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -239,3 +239,17 @@ html:not([data-nfe-enabled='false']) div[data-testid="primaryColumn"] > div:last
 html:not([data-nfe-enabled='false']) table#hnmain .itemlist {
   display: none;
 }
+
+/* LinkedIn */
+html:not([data-nfe-enabled='false']) div.core-rail > div:last-child > div:not(#nfe-container) {
+	opacity: 0 !important;
+	pointer-events: none !important;
+	height: 0 !important;
+}
+
+/* LinkedIn trending news section */
+.right-rail > div:nth-child(2) {
+	opacity: 0 !important;
+	pointer-events: none !important;
+	height: 0 !important;
+}

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -11,6 +11,7 @@ import * as Fb2020 from './sites/fb-2020';
 import * as Twitter from './sites/twitter';
 import * as Reddit from './sites/reddit';
 import * as HackerNews from './sites/hackernews';
+import * as LinkedIn from './sites/linkedin';
 import { createStore, Store } from './store';
 
 const store = createStore();
@@ -25,6 +26,8 @@ export function eradicate(store: Store) {
 		FbClassic.eradicate(store);
 	} else if (HackerNews.checkSite()) {
 		HackerNews.eradicate(store);
+	} else if (LinkedIn.checkSite()) {
+		LinkedIn.eradicate(store);
 	} else  {
 		Fb2020.eradicate(store);
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,9 @@
 		"http://www.reddit.com/",
 		"https://old.reddit.com/",
 		"http://old.reddit.com/",
-		"https://news.ycombinator.com/*"
+		"https://news.ycombinator.com/*",
+		"http://www.linkedin.com/*",
+		"https://www.linkedin.com/*"
 	],
 	"browser_action": {
 		"default_icon": {

--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -1,4 +1,4 @@
-export type SiteId = 'facebook' | 'twitter' | 'reddit' | 'hackernews';
+export type SiteId = 'facebook' | 'twitter' | 'reddit' | 'hackernews' | 'linkedin';
 export const Sites: Record<SiteId, Site> = {
 	facebook: {
 		label: 'Facebook',
@@ -31,6 +31,15 @@ export const Sites: Record<SiteId, Site> = {
 		domain: 'news.ycombinator.com',
 		paths: ['/'],
 		origins: ['https://news.ycombinator.com/*'],
+	},
+	linkedin: {
+		label: 'LinkedIn',
+		domain: 'linkedin.com',
+		paths: ['/', '/feed/'],
+		origins: [
+			'http://www.linkedin.com/*',
+			'https://www.linkedin.com/*',
+		],
 	},
 };
 

--- a/src/sites/linkedin.ts
+++ b/src/sites/linkedin.ts
@@ -1,0 +1,33 @@
+import injectUI, {isAlreadyInjected } from '../lib/inject-ui';
+import {isEnabled} from '../lib/is-enabled';
+import {Store} from '../store';
+
+export function checkSite(): boolean {
+  return window.location.host.includes('linkedin.com');
+}
+
+export function eradicate(store: Store) {
+  function eradicateRetry() {
+    const settings = store.getState().settings;
+    if (settings == null || !isEnabled(settings)) {
+      return;
+    }
+
+    // Don't do anything if the UI hasn't loaded yet
+    const feed = document.querySelector('div.core-rail > div:last-child');
+    if (feed == null) {
+      return;
+    }
+
+    const container = feed;
+
+    // Add News Feed Eradicator quote/info panel
+    if (feed && !isAlreadyInjected()) {
+      injectUI(feed, store);
+    }
+  }
+
+  // This delay ensures that the elements have been created by Twitter's
+  // scripts before we attempt to replace them
+  setInterval(eradicateRetry, 1000);
+}


### PR DESCRIPTION
Adding linkedin feed eradicator inspired from @tomquirk's https://github.com/jordwest/news-feed-eradicator/pull/89, which needs more work on top of @jordwest's recent refactor. This PR follows the simplistic approach of hiding the feed element in CSS and appending the nfeContainer (for quotes) in JS. 

In addition, this PR also removes linkedin's trending news panel on the right just like it's done for twitter and reddit.

Tested and verified that there are no corner cases where feed accidentally shows up again.