### PR TITLE
Add /news to Hacker News block list

### DIFF
--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -54,7 +54,7 @@ export const Sites: Record<SiteId, Site> = {
 	hackernews: {
 		label: 'Y Combinator News (HN)',
 		domain: 'news.ycombinator.com',
-		paths: ['/'],
+		paths: ['/', '/news'],
 		origins: ['https://news.ycombinator.com/*'],
 	},
 	github: {


### PR DESCRIPTION
The Hacker News feed is both on root and https://news.ycombinator.com/news