### PR TITLE
Fix Linkedin Trending News section

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -252,7 +252,7 @@ html:not([data-nfe-enabled='false']) main.scaffold-layout__main > div:last-child
 }
 
 /* LinkedIn trending news section */
-.right-rail > div:nth-child(2) {
+aside.scaffold-layout__aside > div:nth-child(2) {
   opacity: 0 !important;
   pointer-events: none !important;
   height: 0 !important;


### PR DESCRIPTION
Trending news is not addressable via `.right-rail` anymore and has moved to `aside.scaffold-layout__aside`.

Adds to addressing #134.