### PR TITLE
Feature: eradicate suggested videos from odysee.com home page 

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -288,3 +288,16 @@ html:not([data-nfe-enabled='false']) main > section > :not(#nfe-container) {
 html:not([data-nfe-enabled='false']) main > section > #nfe-container {
 	width: 100%;
 }
+
+/* Odysee */
+html:not([data-nfe-enabled='false']) #main-content > :not(#nfe-container) {
+	opacity: 0 !important;
+	pointer-events: none !important;
+	height: 0 !important;
+	padding: 0 !important;
+	margin: 0 !important;
+}
+
+html[theme='dark'] #main-content > #nfe-container .nfe-quote-text {
+	color: white;
+}

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -15,6 +15,7 @@ import * as Github from './sites/github';
 import * as LinkedIn from './sites/linkedin';
 import * as Instagram from './sites/instagram';
 import * as YouTube from './sites/youtube';
+import * as Odysee from './sites/odysee';
 import { createStore, Store } from './store';
 
 const store = createStore();
@@ -22,6 +23,9 @@ const store = createStore();
 export function eradicate(store: Store) {
 	// Determine which site we're working with
 	switch (true) {
+		case Odysee.checkSite():
+			Odysee.eradicate(store);
+			break;
 		case Reddit.checkSite():
 			Reddit.eradicate(store);
 			break;

--- a/src/intercept.ts
+++ b/src/intercept.ts
@@ -21,25 +21,35 @@ const store = createStore();
 
 export function eradicate(store: Store) {
 	// Determine which site we're working with
-	if (Reddit.checkSite()) {
-		Reddit.eradicate(store);
-	} else if (Twitter.checkSite()) {
-		Twitter.eradicate(store);
-	} else if (HackerNews.checkSite()) {
-		HackerNews.eradicate(store);
-	} else if (Github.checkSite()) {
-		Github.eradicate(store);
-	} else if (LinkedIn.checkSite()) {
-		LinkedIn.eradicate(store);
-	} else if (YouTube.checkSite()) {
-		YouTube.eradicate(store);
-	} else if (Instagram.checkSite()) {
-		Instagram.eradicate(store);
-	} else if (FbClassic.checkSite()) {
-		FbClassic.eradicate(store);
-	} else  {
-		Fb2020.eradicate(store);
-  }
+	switch (true) {
+		case Reddit.checkSite():
+			Reddit.eradicate(store);
+			break;
+		case Twitter.checkSite():
+			Twitter.eradicate(store);
+			break;
+		case HackerNews.checkSite():
+			HackerNews.eradicate(store);
+			break;
+		case Github.checkSite():
+			Github.eradicate(store);
+			break;
+		case LinkedIn.checkSite():
+			LinkedIn.eradicate(store);
+			break;
+		case YouTube.checkSite():
+			YouTube.eradicate(store);
+			break;
+		case Instagram.checkSite():
+			Instagram.eradicate(store);
+			break;
+		case FbClassic.checkSite():
+			FbClassic.eradicate(store);
+			break;
+		default:
+			Fb2020.eradicate(store);
+			break;
+	}
 }
 
 setupRouteChange(store);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,9 @@
 		"https://www.github.com/*",
 		"https://github.com/*",
 		"http://www.instagram.com/*",
-		"https://www.instagram.com/*"
+		"https://www.instagram.com/*",
+		"http://odysee.com/*",
+		"https://odysee.com/*"
 	],
 	"browser_action": {
 		"default_icon": {

--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -1,4 +1,4 @@
-export type SiteId = 'facebook' | 'twitter' | 'reddit' | 'hackernews' | 'linkedin' | 'youtube' | 'instagram' | 'github';
+export type SiteId = 'facebook' | 'twitter' | 'reddit' | 'hackernews' | 'linkedin' | 'youtube' | 'instagram' | 'github'	| 'odysee';
 
 export const Sites: Record<SiteId, Site> = {
 	facebook: {
@@ -69,6 +69,12 @@ export const Sites: Record<SiteId, Site> = {
 		domain: 'github.com',
 		paths: ['/'],
 		origins: ['https://github.com/*'],
+	},
+	odysee: {
+		label: 'Odysee',
+		domain: 'odysee.com',
+		paths: ['/'],
+		origins: ['https://odysee.com/*', 'https://odysee.com/*'],
 	},
 };
 

--- a/src/sites/odysee.ts
+++ b/src/sites/odysee.ts
@@ -1,0 +1,34 @@
+import injectUI, { isAlreadyInjected } from '../lib/inject-ui';
+import { isEnabled } from '../lib/is-enabled';
+import { Store } from '../store';
+
+export function checkSite(): boolean {
+	return window.location.host.includes('odysee.com');
+}
+
+export function eradicate(store: Store) {
+	function eradicateRetry() {
+		const settings = store.getState().settings;
+		if (settings == null || !isEnabled(settings)) {
+			return;
+		}
+
+		// Don't do anything if the UI hasn't loaded yet
+		const feed = document.querySelector('#main-content');
+
+		if (feed == null) {
+			return;
+		}
+
+		const container = feed;
+
+		// Add News Feed Eradicator quote/info panel
+		if (container && !isAlreadyInjected()) {
+			injectUI(container, store);
+		}
+	}
+
+	// This delay ensures that the elements have been created before we attempt
+	// to replace them
+	setInterval(eradicateRetry, 1000);
+}


### PR DESCRIPTION
### Disclaimer
This is my very first merge request to a project with multiple developers contributing to it, any advice to improve will be appreciated.

### Purpose of my merge request
Eradicate Oydsee.com homepage feed the same way news-feed-eradicator does it with Youtube.com.

### Test
Here is how the UI behave when the code is running as a temporary extension in Firefox with odysee being eradicated :

![image](https://user-images.githubusercontent.com/73464907/163990219-3b8d2e8c-74da-4fb4-b23e-17ed5bc5af57.png)


