### PR TITLE
Update instagram.ts

### DIFF
--- a/src/sites/instagram.ts
+++ b/src/sites/instagram.ts
@@ -14,7 +14,7 @@ export function eradicate(store: Store) {
     }
 
     // Don't do anything if the UI hasn't loaded yet
-    const feed = document.querySelector('main > section');
+    const feed = document.querySelector('main');
     if (feed == null) {
       return;
     }


### PR DESCRIPTION
Fix blocking instagram after page layout changed.

The selector currently looks for `main > section`, but the new page layout has a div between the two.

I considered doing `main > div`, but thought the easiest thing is to block all of `main`. 

<img width="695" alt="image" src="https://user-images.githubusercontent.com/9088047/180329251-673799f8-6642-4d82-a562-e8dbdee25e85.png">


Here's what blocking all of main looks like (without the quotes)
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/9088047/180329351-d2546663-cc0b-4596-b0dd-6536a35691a0.png">

