### PR TITLE
Eradicate story at Facebook

### DIFF
--- a/src/sites/fb-2020.ts
+++ b/src/sites/fb-2020.ts
@@ -33,10 +33,37 @@ export function eradicate(store: Store) {
 		// Add News Feed Eradicator quote/info panel
 		if (container && !isAlreadyInjected()) {
 			injectUI(container, store);
+			remove_story();
 		}
 	}
 
 	// This delay ensures that the elements have been created by Facebook's
 	// scripts before we attempt to replace them
 	setInterval(eradicateRetry, 1000);
+}
+
+//@ts-nocheck
+function remove_story(){
+	let story = document.querySelector('[role=region]')
+	if (story == null) {
+		return
+	}
+
+	// Hidden all story feeds
+	for (let i = 0; i <  story.children[1].children[0].children.length; i++) {
+		// Still able to create new story
+		if (i == 0) {
+			continue
+		}
+		let child = story.children[1].children[0].children[i]
+		// Make others' story invisible and unclickable
+		// @ts-ignore
+		child.style.opacity = 0
+		// @ts-ignore
+		child.style['pointer-events'] = 'none'
+	}
+	// @ts-ignore
+	story.children[2].hidden = true 
+	
+	
 }


### PR DESCRIPTION
As the image shows, I add some codes to allow the news-feed-eradicator to remove story feeds from friends. That is very distracting when I just want to go to Facebook to view notifications.

P.S. My PR may require some extra work to make it more TypeScript, as I don't know TypeScript very well, I simply use `// @ts-ignore` to ignore type errors.

<img width="257" alt="image" src="https://user-images.githubusercontent.com/43432631/187606921-8606e25d-6604-4639-8b94-b40cc8d038d6.png">
