### PR TITLE
Fix Github home, convert to using CSS

### DIFF
--- a/src/sites/github.str.css
+++ b/src/sites/github.str.css
@@ -1,0 +1,40 @@
+/* GitHub Home (feed, footer links, change log ,explore repo) */
+
+html:not([data-nfe-enabled='false'])
+	aside[aria-label='Account']
+	+ div
+	div[role='contentinfo'],
+html:not([data-nfe-enabled='false'])
+	aside[aria-label='Account']
+	+ div
+	aside[aria-label='Explore'] {
+	opacity: 0 !important;
+	pointer-events: none !important;
+	height: 0 !important;
+	overflow-y: hidden !important;
+}
+
+html:not([data-nfe-enabled='false'])
+	aside[aria-label='Account']
+	+ div
+	#dashboard-feed-frame
+	> :not(#nfe-container) {
+	display: none;
+	/* fix Chrome not overflow:hidden with way above*/
+}
+
+/* addtional: stretch quote full width */
+html:not([data-nfe-enabled='false'])
+	aside[aria-label='Account']
+	+ div
+	aside[aria-label='Explore'] {
+	width: 0 !important;
+}
+
+html:not([data-nfe-enabled='false'])
+	aside[aria-label='Account']
+	+ div
+	> [class*='d-'][class*='-flex']
+	> :first-child {
+	width: 100% !important;
+}

--- a/src/sites/github.ts
+++ b/src/sites/github.ts
@@ -14,31 +14,11 @@ export function eradicate(store: Store) {
 			return;
 		}
 
-		let feedSelector: string = '';
-
-		const feedSelector1 =
-			'#dashboard > div > div:nth-child(3)[data-repository-hovercards-enabled]';
-		const feedSelector2 =
-			'#dashboard > div > div:nth-child(5)[data-repository-hovercards-enabled]';
-
-		if (document.querySelector(feedSelector1)) {
-			feedSelector = feedSelector1;
-		} else if (document.querySelector(feedSelector2)) {
-			feedSelector = feedSelector2;
-		}
-
 		// Don't do anything if the UI hasn't loaded yet
-		if (feedSelector.length === 0) return;
+		const feed = document.querySelector('#dashboard-feed-frame');
+		if (feed === null) return;
 
-		const proTipsSelector = '#dashboard > div > div.f6.text-gray.mt-4';
-		const allActivityHeader =
-			'#dashboard > div > h2.f4.text-normal.js-all-activity-header';
-
-		remove({ toRemove: [feedSelector, proTipsSelector, allActivityHeader] });
-
-		const container = document.querySelector(
-			'body > div.application-main > div > div > div > main'
-		);
+		const container = feed;
 
 		// Add News Feed Eradicator quote/info panel
 		if (container && !isAlreadyInjected()) {
@@ -46,7 +26,7 @@ export function eradicate(store: Store) {
 		}
 	}
 
-	// This delay ensures that the elements have been created by Twitter's
+	// This delay ensures that the elements have been created by GitHub's
 	// scripts before we attempt to replace them
 	setInterval(eradicateRetry, 1000);
 }

--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -1,5 +1,6 @@
 import instagramCss from './instagram.str.css';
 import twitterCss from './twitter.str.css';
+import githubCss from './github.str.css';
 
 export type SiteId =
 	| 'facebook'
@@ -85,8 +86,9 @@ export const Sites: Record<SiteId, Site> = {
 	github: {
 		label: 'Github',
 		domain: 'github.com',
-		paths: ['/'],
+		paths: ['/', '/dashboard'],
 		origins: ['https://github.com/*'],
+		css: githubCss,
 	},
 };
 


### PR DESCRIPTION
Fix: #211 
I've just handled on the home page ('`/`', '`/dashboard`'). It's great to hear your feedback for improvement. 

Thank you, fellows, for creating and maintaining this add-ons.

---
(What I replaced; Run with Firefox, Chrome on Window)

![what removed](https://user-images.githubusercontent.com/74447462/210019949-a9c1d070-73b8-4cac-bd65-2abf3f69a75c.png)
