### PR TITLE
Fix: eradicate stories for non-english versions of fb

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -199,8 +199,10 @@ html:not([data-nfe-enabled='false']) #ssrb_feed_start + div, /* For home and gro
 html:not([data-nfe-enabled='false']) div[data-pagelet='MainFeed'], /* For watch and marketplace feeds */
 html:not([data-nfe-enabled='false']) div[aria-label='Gaming'][role='main'],
 html:not([data-nfe-enabled='false']) div[aria-label='Stories'],
-html:not([data-nfe-enabled='false']) div.x1hc1fzr.x1unhpq9.x6o7n8i > :not(#nfe-container) {
-	/* For new fb layout (Q4 2022) */
+html:not([data-nfe-enabled='false'])
+div.x1hc1fzr.x1unhpq9.x6o7n8i > :not(#nfe-container), /* For new fb layout (Q4 2022) */
+html:not([data-nfe-enabled='false'])
+div[role='region'][data-visualcompletion='ignore-dynamic'] /* For stories in non-english versions */ {
 	position: absolute !important;
 	opacity: 0 !important;
 	pointer-events: none !important;


### PR DESCRIPTION
This fixes the bug where stories were not eradicated for users who are not using english version of FB

As discovered in #216 aria-label is being translated if user is using fb in other languages, so the selectors were not eradicating stories container for them.

I chose to target the stories container with `div[role='region'][data-visualcompletion='ignore-dynamic']` which is not perfect but there was no other way to distinguish it from other elements except for targeting the ridiculous auto-generated class name `x1n2onr6 x121yvx8 xjkvuk6 xieb3on x9otpla x1iorvi4` and i don't know which would be worse.

The idea of targeting it in js like Eason did in #216 unfortunately does not work consistently because divs with `[role=region]` seem to be loading in different order and and in variable quantity, so sometimes the selector would match some unrelated element.

It works for me, tested it on chrome on various languages.