### PR TITLE
Added Firefox android support

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -55,6 +55,10 @@
 	"browser_specific_settings": {
 		"gecko": {
 			"id": "@news-feed-eradicator"
+		},
+		"gecko_android": {
+			"id": "@news-feed-eradicator",
+			"strict_min_version": "113.0"
 		}
 	}
 }

--- a/src/sites/instagram.str.css
+++ b/src/sites/instagram.str.css
@@ -8,3 +8,9 @@ html:not([data-nfe-enabled='false']) main > #nfe-container {
 	font-size: 24px;
 	padding: 128px;
 }
+
+@media (max-width: 767px) {
+	html:not([data-nfe-enabled='false']) main > #nfe-container {
+		padding: 0;
+	}
+}


### PR DESCRIPTION
Related issue: #67 

I added support to install the extension on Firefox android.

based on my testings It's working fine for:
- Instagram
- Hacker news

For other websites, we have to updates its selectors (e.g. LinkedIn) or its domain (e.g. Youtube uses m.youtube.com on mobile)