### PR TITLE
Updated 'twitter.com' domain to 'x.com'

### DIFF
--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -40,7 +40,7 @@ export const Sites: Record<SiteId, Site> = {
 	},
 	twitter: {
 		label: 'Twitter/X',
-		domain: 'twitter.com',
+		domain: 'x.com',
 		paths: ['/home', '/compose/tweet'],
 		origins: [
 			'http://twitter.com/*',


### PR DESCRIPTION
The extension stopped working on Twitter because of the change of domain from twitter.com to x.com, so it has been updated