### PR TITLE
Fix Linkedin feed eradicator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "news-feed-eradicator",
-	"version": "2.2.7",
+	"version": "2.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "news-feed-eradicator",
-			"version": "2.2.7",
+			"version": "2.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "^8.10.36"

--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -254,7 +254,7 @@ html:not([data-nfe-enabled='false']) table#hnmain tr:nth-of-type(3) td > table {
 
 /* LinkedIn */
 html:not([data-nfe-enabled='false'])
-	main.scaffold-layout__main
+	main
 	> div:last-child
 	> div:not(#nfe-container) {
 	opacity: 0 !important;


### PR DESCRIPTION
This PR fixes the Linkedin feed eradicator by removing the now deprecated class `scaffold-layout__main` from the main tag

Resolves #319, resolves #318 