### PR TITLE
Fix selector for old reddit

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -239,7 +239,7 @@ html:not([data-nfe-enabled='false'])
 
 /* Reddit old */
 html:not([data-nfe-enabled='false'])
-	.listing-page.with-listing-chooser
+	.listing-page
 	.content
 	#siteTable {
 	opacity: 0 !important;


### PR DESCRIPTION
Currently the second class of the listing div isn't called `with-listing-chooser` anymore, but rather `hot-page` or `new-page` depending on the feed. So currently old reddit newsfeed blocking doesn't work. This fixes it by simply not specifying the second class name