### PR TITLE
ref: update Marie's surname

### DIFF
--- a/src/quote.ts
+++ b/src/quote.ts
@@ -229,7 +229,7 @@ export const BuiltinQuotes: Array<BuiltinQuote> = [
 	{
 		id: 46,
 		text: 'We must believe that we are gifted for something, and that this thing, at whatever cost, must be attained.',
-		source: 'Marie Curie',
+		source: 'Marie Skłodowska-Curie',
 	},
 	{
 		id: 47,


### PR DESCRIPTION
# Change

Updated reference from “Marie Curie” to “Marie Skłodowska-Curie” to reflect her full name as she used it professionally and in publications, preserving historical and cultural accuracy.