### PR TITLE
fix: improve Reddit dark mode contrast and visibility

### DIFF
--- a/src/eradicate.css
+++ b/src/eradicate.css
@@ -44,12 +44,21 @@ html[data-nfe-enabled='false'] #nfe-container {
 }
 
 .__fb-dark-mode .nfe-quote-text,
-body[data-nfe-color-scheme='dark'] .nfe-quote-text {
+body[data-nfe-color-scheme='dark'] .nfe-quote-text,
+body.theme-dark .nfe-quote-text,
+html:not(.theme-light) .nfe-quote-text {
 	color: white;
 }
 
 .nfe-quote-source {
 	color: #999;
+}
+
+.__fb-dark-mode .nfe-quote-source,
+body[data-nfe-color-scheme='dark'] .nfe-quote-source,
+body.theme-dark .nfe-quote-source,
+html:not(.theme-light) .nfe-quote-source {
+	color: #ccc;
 }
 
 .nfe-quote-action-menu {
@@ -97,12 +106,28 @@ body[data-nfe-color-scheme='dark'] .nfe-quote-text {
 	font-size: 14px;
 }
 
+.__fb-dark-mode .nfe-quote-action-menu-content,
+body[data-nfe-color-scheme='dark'] .nfe-quote-action-menu-content,
+body.theme-dark .nfe-quote-action-menu-content,
+html:not(.theme-light) .nfe-quote-action-menu-content {
+	background-color: #333;
+	border: 1px solid #555;
+	box-shadow: 5px 5px 15px #000;
+}
+
 .nfe-quote-action-menu-item {
 	display: block;
 	padding: 5px 5px 5px 15px;
 	color: #000;
 	border-top: 1px solid transparent;
 	border-bottom: 1px solid transparent;
+}
+
+.__fb-dark-mode .nfe-quote-action-menu-item,
+body[data-nfe-color-scheme='dark'] .nfe-quote-action-menu-item,
+body.theme-dark .nfe-quote-action-menu-item,
+html:not(.theme-light) .nfe-quote-action-menu-item {
+	color: #fff;
 }
 
 .nfe-quote-action-menu-item:hover {
@@ -126,6 +151,21 @@ body[data-nfe-color-scheme='dark'] .nfe-quote-text {
 	font-size: 18px;
 	display: block;
 	background-color: #ddd;
+}
+
+.__fb-dark-mode .nfe-info-link,
+body[data-nfe-color-scheme='dark'] .nfe-info-link,
+body.theme-dark .nfe-info-link,
+html:not(.theme-light) .nfe-info-link {
+	color: #99c;
+}
+
+.__fb-dark-mode .nfe-info-link:hover,
+body[data-nfe-color-scheme='dark'] .nfe-info-link:hover,
+body.theme-dark .nfe-info-link:hover,
+html:not(.theme-light) .nfe-info-link:hover {
+	color: #99c;
+	background-color: #333;
 }
 
 .nfe-info-link img {

--- a/src/sites/reddit.ts
+++ b/src/sites/reddit.ts
@@ -34,6 +34,17 @@ export function eradicate(store: Store) {
 			// Hack so that injectUI can handle new-reddit theme
 			document.body.style.background = 'var(--newRedditTheme-body)';
 
+			// Detect Reddit's dark mode and set appropriate data attribute
+			if (
+				document.body.classList.contains('theme-dark') ||
+				document.documentElement.classList.contains('theme-dark') ||
+				(!document.body.classList.contains('theme-light') &&
+					!document.documentElement.classList.contains('theme-light') &&
+					window.matchMedia('(prefers-color-scheme: dark)').matches)
+			) {
+				document.body.dataset.nfeColorScheme = 'dark';
+			}
+
 			injectUI(container, store, { asFirstChild: true });
 		}
 	}

--- a/src/sites/twitter.str.css
+++ b/src/sites/twitter.str.css
@@ -8,8 +8,10 @@ html:not([data-nfe-enabled='false'])
 }
 
 html:not([data-nfe-enabled='false']) div[aria-label*='Timeline'],
-html:not([data-nfe-enabled='false']) div[data-testid="primaryColumn"] > div:last-child > div:last-child
-{
+html:not([data-nfe-enabled='false'])
+	div[data-testid='primaryColumn']
+	> div:last-child
+	> div:last-child {
 	opacity: 0 !important;
 	pointer-events: none !important;
 }


### PR DESCRIPTION
- Add support for Reddit's theme-dark class and system dark mode preference
- Enhance dark mode CSS selectors to include body.theme-dark and html:not(.theme-light)
- Improve contrast for quote text, source attribution, action menus, and info links
- Add explicit Reddit dark mode detection in reddit.ts with fallback to system preference
- Ensure all UI elements are properly visible in both light and dark themes