### PR TITLE
Fix LinkedIn feed eradication by including iframes

### DIFF
--- a/src/background/store/effects.ts
+++ b/src/background/store/effects.ts
@@ -145,6 +145,7 @@ export const registerContentScripts: BackgroundEffect =
 					css: ['eradicate.css'],
 					matches: siteMatches,
 					runAt: 'document_start',
+					allFrames: true,
 				},
 			]);
 		}

--- a/src/sites/index.ts
+++ b/src/sites/index.ts
@@ -60,7 +60,7 @@ export const Sites: Record<SiteId, Site> = {
 	linkedin: {
 		label: 'LinkedIn',
 		domain: ['linkedin.com'],
-		paths: ['/', '/feed/'],
+		paths: ['/', '/feed/', '/preload/'],
 		origins: ['http://www.linkedin.com/*', 'https://www.linkedin.com/*'],
 		css: linkedinCss,
 	},

--- a/src/sites/linkedin.str.css
+++ b/src/sites/linkedin.str.css
@@ -1,5 +1,6 @@
 /* LinkedIn */
 html:not([data-nfe-enabled='false'])
+	main[aria-label='Main Feed']
 	.scaffold-finite-scroll
 	> div:not(#nfe-container) {
 	opacity: 0 !important;

--- a/src/sites/linkedin.ts
+++ b/src/sites/linkedin.ts
@@ -17,7 +17,9 @@ export function eradicate(store: Store) {
 		}
 
 		// Don't do anything if the UI hasn't loaded yet
-		const feed = document.querySelector('.scaffold-finite-scroll');
+		const feed = document.querySelector(
+			"main[aria-label='Main Feed'] .scaffold-finite-scroll"
+		);
 		if (feed == null) {
 			return;
 		}

--- a/src/webextension.ts
+++ b/src/webextension.ts
@@ -57,6 +57,7 @@ type RegisteredContentScript = {
 	css?: string[];
 	matches: string[];
 	runAt: 'document_start' | 'document_end' | 'document_idle';
+	allFrames: boolean;
 };
 
 type WebExtensionEvent<Arg> = {


### PR DESCRIPTION
### Issue
Upon initial load of LinkedIn home page, the news feed is correctly eradicated. But after navigating to another page (e.g. Jobs) and then back to the home page, the news feed is no longer eradicated, unless an full page reload is triggered.

I noticed that in the above scenario, on re-rendering, html was being added to a newly created iframe.

By default, extension scripts and styles are not injected into iframes, which is why the feed was not being eradicated.

### Fix

Run extension on all iframes.

### Testing
- ran on chrome (version 140.0), verified that the above issue is now resolved and that the other pages on LinkedIn are still working correctly

### TODOS
- [ ] smoke test other news feed eradicator websites to ensure that iframe inclusion hasn't caused any issues