### PR TITLE
Fix snooze applying to all sites

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,17 +1,12 @@
 import "solid-js";
 
-declare module "*?raw"
-{
-    const content: string;
-    export default content;
-}
-
 // Augment the solid-js JSX namespace
 declare module "solid-js" {
-  namespace JSX {
-    interface IntrinsicElements {
-      // Add your custom element name here and combine its attributes
-      "nfe-tabs": SolidJSX.IntrinsicElements["div"];
-    }
-  }
+	namespace JSX {
+		interface IntrinsicElements {
+			// Add your custom element name here and combine its attributes
+			"nfe-tabs": SolidJSX.IntrinsicElements["div"];
+		}
+	}
 }
+

--- a/raw-modules.d.ts
+++ b/raw-modules.d.ts
@@ -1,0 +1,10 @@
+declare module "*?raw" {
+	const content: string;
+	export default content;
+}
+
+declare module "*.css?raw" {
+	const content: string;
+	export default content;
+}
+

--- a/src/lib/webextension.ts
+++ b/src/lib/webextension.ts
@@ -45,6 +45,7 @@ export type TabId = number & { __tabId: never };
 type Storage = {
 	get(keys: string | string[] | null): Promise<any>;
 	set(keys: object): Promise<void>;
+	remove(keys: string | string[]): Promise<void>;
 };
 
 type OnInstalledDetails = {

--- a/src/messaging/messages.ts
+++ b/src/messaging/messages.ts
@@ -39,7 +39,7 @@ type OptionsUpdated = {
 	type: 'nfe#optionsUpdated',
 }
 
-export type ToServiceWorkerMessage = RequestSiteDetails | OpenOptionsPage | NotifyOptionsUpdated | SetSiteTheme | EnableSite | DisableSite | Snooze | RequestQuote | SetQuoteEnabled | InjectCss | RemoveCss | ReadSnooze;
+export type ToServiceWorkerMessage = RequestSiteDetails | OpenOptionsPage | NotifyOptionsUpdated | SetSiteTheme | EnableSite | DisableSite | Snooze | RequestQuote | SetQuoteEnabled | ReadSnooze;
 
 // Request site details from service worker.
 type RequestSiteDetails = {
@@ -92,9 +92,11 @@ type DisableSite = {
 
 type Snooze = {
 	type: 'snooze',
+	siteId: SiteId,
 	until: number
 }
 
 type ReadSnooze = {
 	type: 'readSnooze',
+	siteId: SiteId,
 }

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -15,7 +15,11 @@ export type StorageLocalV2 = {
 	settingsLocked?: boolean;
 	enabledSites?: SiteId[];
 	siteConfig?: Record<SiteId, SiteConfig>;
+	/**
+	 * @deprecated Legacy global snooze; migrated to `snoozeUntilBySite`.
+	 */
 	snoozeUntil?: number;
+	snoozeUntilBySite?: Partial<Record<SiteId, number>>;
 	quoteLists?: QuoteList[];
 	widgetStyle?: 'contained' | 'transparent';
 	regionHideStyle?: 'blur' | 'hidden';


### PR DESCRIPTION
Snooze was stored globally (`snoozeUntil`) and disabled region blocking across every enabled site. This PR scopes snooze to the site currently selected in the Options → Sites tab.

- Store snooze in `snoozeUntilBySite[siteId]` (with migration from legacy global `snoozeUntil`)
- Service worker reads/writes snooze per-site and returns that site's `snoozeUntil` to content scripts
- Options Snooze UI/actions require a selected site and show which site is being snoozed

Tested: `bun x tsc -p tsconfig.json --noEmit`, `bun run src/dev/build.ts`