### PR TITLE
block posts on Posts For You section of Explore tab of X

### DIFF
--- a/src/sitelist/twitter.ts
+++ b/src/sitelist/twitter.ts
@@ -19,6 +19,15 @@ export const site: Site = {
 						mode: 'overlay',
 					}
 				},
+				{
+					id: regionId('explore-posts'),
+					title: 'Explore "Posts For You"',
+					type: 'remove',
+					paths: ['/explore'],
+					selectors: [
+					'div[data-testid="primaryColumn"] div[data-testid="cellInnerDiv"]:has(article[data-testid="tweet"])',
+					],
+				},
 			]
 		}
 


### PR DESCRIPTION
## Hide "Posts For You" tweets on X Explore page

The X/Twitter Explore page (`x.com/explore`) displays a "Posts For You" section with algorithmically recommended tweets — the same type of addictive content the extension already blocks on the main timeline. This adds a new region to hide those recommended posts.

### Changes

- **`src/sitelist/twitter.ts`**: Added an `explore-posts` region that targets `cellInnerDiv` containers holding tweet articles (`data-testid="tweet"`) on the `/explore` path, using `type: 'remove'` to hide them via `display: none`.

### What's preserved

- Trending topics and "Who to follow" sections remain visible on Explore
- Home timeline behavior is unchanged (still hidden with quote overlay)
- Search results and sub-tabs under `/explore/` are unaffected (region is scoped to `/explore` exactly)
- New region appears as a toggleable option in extension settings

### No other files changed

The region processing system is fully generic — adding a region entry is all that's needed. No changes to the manifest, content script, service worker, or type definitions.
