### PR TITLE
Add YouTube subscriptions feed toggle

### DIFF
--- a/src/sitelist/youtube.ts
+++ b/src/sitelist/youtube.ts
@@ -18,6 +18,17 @@ export const site: Site = {
 					},
 				},
 				{
+					id: regionId('subscriptions-feed'),
+					title: 'Subscriptions feed',
+					selectors: ['ytd-browse'],
+					paths: ['/feed/subscriptions'],
+					type: 'hide',
+					inject: {
+						mode: 'overlay-fixed',
+						overlayZIndex: 2019,
+					},
+				},
+				{
 					id: regionId('shorts-button'),
 					title: 'Shorts button',
 					type: 'remove',
@@ -71,7 +82,7 @@ export const site: Site = {
 				},
 				{
 					id: regionId('subscriptions'),
-					title: 'Subscriptions',
+					title: 'Subscriptions sidebar',
 					type: 'remove',
 					paths: '*',
 					selectors: [


### PR DESCRIPTION
## Summary

- add a dedicated YouTube region toggle for `/feed/subscriptions`
- keep the existing main feed paths unchanged so the subscriptions feed can be toggled independently
- rename the existing sidebar subscriptions region to `Subscriptions sidebar` to avoid ambiguity

Addresses discussion #551. Relates to issue #194. PR #556 added a sidebar subscriptions toggle; this adds the page-level subscriptions feed toggle.

## Verification

- `npx --yes bun run src/dev/build.ts`
- confirmed `build/sitelist.json` includes `subscriptions-feed` for `/feed/subscriptions`
- `./node_modules/.bin/tsc --noEmit` currently fails on existing `?raw` CSS module declarations in main; no new TypeScript errors from this change
