### PR TITLE
feat(instagram): block explore page recommendations

### DIFF
--- a/src/sitelist/instagram.ts
+++ b/src/sitelist/instagram.ts
@@ -30,7 +30,14 @@ export const site: Site = {
 			type: 'remove',
 			paths: 'inherit',
 			selectors: ['div:has(> div > a[href="/explore/people/"])']
-		}
+		},
+		{
+            id: regionId('explore-suggestions'),
+            title: 'Explore Suggestions',
+            type: 'remove',
+            paths: ['/explore/'],
+            selectors: ['main div:has(> div > div > a[href^="/p/"])']
+        }
 	]
 }
 


### PR DESCRIPTION
## Description
This PR introduces a new block region to eradicate the recommendations grid on the Instagram Explore page (`/explore/`), resolving a long-standing feature request. 

It handles the state changes smoothly without interfering with the user's ability to use the search bar functionality.

Closes #247
Addresses #260

## Changes Made
- Updated `src/sites/instagram.ts` to include the `'/explore/'` path.
- Added the `explore-suggestions` region using a content-aware `:has()` selector targeting post/reel links (`main div:has(> div > div > a[href^="/p/"])`).
- Set the operation type to `'remove'` to cleanly drop the feed without messing with the search bar layout or requiring an unnatural quote overlay layout.

## Validations & Testing Done
- Tested locally on Chromium.
- **Explore Page Cleanliness:** Verified the infinite scroll recommendations grid is completely blocked upon navigating to `/explore/`.
- **Search Bar Check:** Confirmed that clicking the search bar and typing a query properly displays the search results dropdown without the elements being accidentally swallowed or deleted by the extension engine.

## Visual Proof

| Clean Explore Page (Eradicated) | Active Search State (Functional) |
| :---: | :---: |
| <img width="100%" alt="Eradicated Explore Page" src="https://github.com/user-attachments/assets/17400b23-57a8-4a6f-a242-3a2b6f3e7e24" /> | <img width="100%" alt="Working Search Dropdown" src="https://github.com/user-attachments/assets/1d953bbe-d8e0-4fc6-9878-d6c320051794" /> |