### PR TITLE
Fix security error from sitelist.json fetch in content script

### DIFF
--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -268,10 +268,13 @@ export const setRegionEnabledForSite = async (siteId: SiteId, regionId: RegionId
 	return setKey('siteConfig', siteConfig);
 }
 
-const browser = getBrowser();
-const siteListUrl = browser.runtime.getURL('sitelist.json');
-const siteListPromise: Promise<SiteList> = fetch(siteListUrl).then(siteList => siteList.json());
+let siteListPromise: Promise<SiteList> | undefined;
 
 export const loadSitelist = async (): Promise<SiteList> => {
+	if (siteListPromise == null) {
+		const browser = getBrowser();
+		const siteListUrl = browser.runtime.getURL('sitelist.json');
+		siteListPromise = fetch(siteListUrl).then(siteList => siteList.json());
+	}
 	return siteListPromise
 }


### PR DESCRIPTION
storage.ts fetched sitelist.json at module load, which also ran inside the content script bundle (via quote-widget.tsx) since it imports storage.ts for unrelated helpers. Firefox blocks a moz-extension:// fetch from a page context, logging a security error on every site, even though the content script never consumed the result.

Make the fetch lazy and memoized inside loadSitelist(), which only the service worker calls.

Fixes #578.