### PR TITLE
feat(sitelist): add TikTok support and Facebook Reels blocking

### DIFF
--- a/src/entrypoints/intercept/intercept.tsx
+++ b/src/entrypoints/intercept/intercept.tsx
@@ -20,7 +20,7 @@ const sendMessage = (message: ToServiceWorkerMessage) => browser.runtime.sendMes
 
 const shouldBlockNavigation = (url: string | URL): boolean => {
 	try {
-		const path = new URL(url, location.origin).pathname;
+			const path = new URL(url.toString(), location.href).pathname;
 		return blockedNavigationPatterns.some(pattern => pattern.test(path));
 	} catch {
 		return false;

--- a/src/entrypoints/intercept/intercept.tsx
+++ b/src/entrypoints/intercept/intercept.tsx
@@ -13,7 +13,73 @@ const browser = getBrowser();
 
 const token = Math.floor(Math.random() * 1000000);
 
+let navigationBlockingReady = false;
+let blockedNavigationPatterns: RegExp[] = [];
+
 const sendMessage = (message: ToServiceWorkerMessage) => browser.runtime.sendMessage(message);
+
+const shouldBlockNavigation = (url: string | URL): boolean => {
+	try {
+		const path = new URL(url, location.origin).pathname;
+		return blockedNavigationPatterns.some(pattern => pattern.test(path));
+	} catch {
+		return false;
+	}
+}
+
+const blockCurrentNavigation = () => {
+	if (shouldBlockNavigation(location.pathname)) {
+		location.replace('/');
+	}
+}
+
+const setupNavigationBlocking = () => {
+	if (navigationBlockingReady) return;
+	navigationBlockingReady = true;
+
+	document.addEventListener('click', event => {
+		const target = event.target;
+		if (!(target instanceof Element)) return;
+
+		const link = target.closest('a[href]');
+		if (!(link instanceof HTMLAnchorElement)) return;
+
+		if (shouldBlockNavigation(link.href)) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+	}, true);
+
+	const pushState = history.pushState;
+	history.pushState = function (this: History, ...args: Parameters<History['pushState']>) {
+		if (args[2] != null && shouldBlockNavigation(args[2])) return;
+		return pushState.apply(this, args);
+	};
+
+	const replaceState = history.replaceState;
+	history.replaceState = function (this: History, ...args: Parameters<History['replaceState']>) {
+		if (args[2] != null && shouldBlockNavigation(args[2])) return;
+		return replaceState.apply(this, args);
+	};
+
+	window.addEventListener('popstate', blockCurrentNavigation);
+}
+
+const setBlockedNavigationPatterns = (patterns: string[]) => {
+	blockedNavigationPatterns = patterns.flatMap(pattern => {
+		try {
+			return [new RegExp(pattern)];
+		} catch (error) {
+			console.warn(`Invalid navigation block pattern: ${pattern}`, error);
+			return [];
+		}
+	});
+
+	if (blockedNavigationPatterns.length > 0) {
+		setupNavigationBlocking();
+		blockCurrentNavigation();
+	}
+}
 
 const domReady = new Promise(resolve => {
 
@@ -265,6 +331,7 @@ const patchState = (regions: DesiredRegionState[]) => {
 	}
 
 	let css = "";
+	let blockedNavigationPatterns: string[] = [];
 
 	// Scan all active regions and delete or update them
 	for (const [id, activeRegion] of state.regions.entries()) {
@@ -300,9 +367,14 @@ const patchState = (regions: DesiredRegionState[]) => {
 		if (activeRegion.css != null && activeRegion.enabled) {
 			css += activeRegion.css + '\n';
 		}
+
+		if (activeRegion.config.blockNavigation != null && activeRegion.enabled) {
+			blockedNavigationPatterns.push(activeRegion.config.blockNavigation);
+		}
 	}
 
 	setCss(css);
+	setBlockedNavigationPatterns(blockedNavigationPatterns);
 }
 
 const isRegionBlockActive = (region: RegionState) => region.enabled && !isSnoozing()

--- a/src/sitelist/_index.ts
+++ b/src/sitelist/_index.ts
@@ -6,6 +6,7 @@ const sitelist: SiteList = {
 		(await import('./facebook')).default,
 		(await import('./instagram')).default,
 		(await import('./youtube')).default,
+		(await import('./tiktok')).default,
 		(await import('./reddit')).default,
 		(await import('./twitter')).default,
 		(await import('./linkedin')).default,

--- a/src/sitelist/facebook.ts
+++ b/src/sitelist/facebook.ts
@@ -24,6 +24,14 @@ export const site: Site = {
 			selectors: ['div.x193iq5w.xgmub6v.x1ceravr.x1v0nzow']
 		},
 		{
+			id: regionId('reels'),
+			title: 'Reels',
+			type: 'remove',
+			paths: '*',
+			selectors: ['[aria-label="Reels"]'],
+			blockNavigation: '^/reel/',
+		},
+		{
 			id: regionId('groups-feed'),
 			title: 'Groups feed',
 			type: 'remove',

--- a/src/sitelist/tiktok.ts
+++ b/src/sitelist/tiktok.ts
@@ -1,0 +1,36 @@
+import { regionId, siteId, type Site } from "../types/sitelist";
+
+export const site: Site = {
+	id: siteId('tiktok'),
+	title: 'TikTok',
+	hosts: ['www.tiktok.com'],
+	paths: ['/', '/foryou', '/following'],
+	regions: [
+		{
+			id: regionId('main-feed'),
+			title: 'Main feed',
+			type: 'hide',
+			paths: 'inherit',
+			selectors: [
+				'[data-e2e="recommend-list"]',
+				'[data-e2e="recommend-list-item-container"]',
+			],
+			inject: {
+				mode: 'overlay-fixed',
+				overlayZIndex: 99999999,
+			}
+		},
+		{
+			id: regionId('video-recommendations'),
+			title: 'Recommended videos on video pages',
+			type: 'remove',
+			paths: [{ regexp: '^/@[^/]+/video/' }],
+			selectors: [
+				'[data-e2e="recommend-list"]',
+				'[data-e2e="recommend-list-item-container"]',
+			],
+		}
+	]
+}
+
+export default site;

--- a/src/types/sitelist.ts
+++ b/src/types/sitelist.ts
@@ -35,4 +35,5 @@ export type Region = {
 	paths: 'inherit' | '*' | PathList,
 	default?: boolean,
 	inject?: Inject,
+	blockNavigation?: string,
 }


### PR DESCRIPTION
## Description

This PR adds two distraction-blocking improvements:

- Adds Facebook Reels as a removable Facebook region.
- Adds TikTok support focused on blocking feed-style surfaces while keeping non-feed features like DMs usable.

It also introduces a small reusable `blockNavigation` option for regions. This is used for Facebook Reels because the sidebar element can briefly appear before CSS catches it, allowing fast clicks into `/reel/` routes.

## Changes Made

- Added optional `blockNavigation` support to `Region`.
- Added capture-phase click interception for enabled regions with navigation-blocking patterns.
- Added `history.pushState` / `history.replaceState` blocking for matching region paths.
- Added a Facebook `Reels` region:
  - removes `[aria-label="Reels"]`
  - blocks navigation to `/reel/`
- Added TikTok as a new sitelist entry:
  - hides the main feed on `/`, `/foryou`, and `/following`
  - removes recommended-video feed containers on video pages
- Registered TikTok in the sitelist index.

## What's Preserved

- Existing Facebook feed, stories, and groups behavior is unchanged.
- TikTok DMs are not blocked by URL.
- Individual TikTok video pages can still be opened, but feed/recommendation containers are removed where matched.
- YouTube Shorts behavior is unchanged.

## Validations & Testing Done

- Ran `bun install`
- Ran `bun run src/dev/build.ts`
- Ran `git diff --check origin/main...HEAD`

Build completed successfully.
