### PR TITLE
Added new option to separately block the Chronological groups feed

### DIFF
--- a/src/entrypoints/intercept/intercept.tsx
+++ b/src/entrypoints/intercept/intercept.tsx
@@ -195,14 +195,17 @@ function tryInject() {
 	}
 }
 
-let path = window.location.pathname;
+let pathname = window.location.pathname;
+let search = window.location.search;
 setInterval(() => {
-	if (path != window.location.pathname) {
-		path = window.location.pathname;
+	if (pathname != window.location.pathname || search != window.location.search) {
+		pathname = window.location.pathname;
+		search = window.location.search;
 
 		sendMessage({
 			type: 'requestSiteDetails',
-			path: window.location.pathname,
+			path: pathname,
+			search,
 			token
 		});
 	}
@@ -221,6 +224,7 @@ const endSnooze = () => {
 	sendMessage({
 		type: 'requestSiteDetails',
 		path: window.location.pathname,
+		search: window.location.search,
 		token
 	});
 	state.snoozeTimer = undefined;
@@ -331,6 +335,7 @@ browser.runtime.onMessage.addListener(async (msg: FromServiceWorkerMessage) => {
 		sendMessage({
 			type: 'requestSiteDetails',
 			path: window.location.pathname,
+			search: window.location.search,
 			token
 		});
 	}
@@ -349,6 +354,7 @@ const pingServiceWorker = () => {
 	sendMessage({
 		type: 'requestSiteDetails',
 		path: window.location.pathname,
+		search: window.location.search,
 		token
 	});
 

--- a/src/entrypoints/intercept/intercept.tsx
+++ b/src/entrypoints/intercept/intercept.tsx
@@ -6,7 +6,11 @@ import type { Region, RegionId, Site, SiteId } from '../../types/sitelist';
 import { render } from 'solid-js/web';
 import nfeStyles from './nfe-container.css?raw';
 import sharedStyles from '../../shared/styles.css?raw';
-import type { Theme } from '../../storage/schema';
+import type { ResolvedTheme, Theme } from '../../storage/schema';
+import type { WidgetAppearance } from '../../types/sitelist';
+import { resolveTheme, themeCssForResolved } from '../../lib/theme';
+import themeDark from '../../themes/dark.css?raw';
+import themeLight from '../../themes/light.css?raw';
 import { signalObj, type SignalObj } from '/lib/solid-util';
 
 const browser = getBrowser();
@@ -49,10 +53,12 @@ type ContentScriptState = {
 	ready?: boolean;
 	hideQuotes?: boolean;
 	widgetStyle: SignalObj<'contained' | 'transparent'>;
+	widgetAppearance: SignalObj<WidgetAppearance | undefined>;
 	overlays: OverlayState[];
 	theme: {
 		css: string | null;
-		id: SignalObj<Theme | null>;
+		preference: SignalObj<Theme | null>;
+		id: SignalObj<ResolvedTheme | null>;
 	}
 	regions: Map<RegionId, RegionState>;
 };
@@ -61,9 +67,11 @@ let state: ContentScriptState = {
 	regions: new Map(),
 	overlays: [],
 	widgetStyle: signalObj<'contained' | 'transparent'>('contained'),
+	widgetAppearance: signalObj<WidgetAppearance | undefined>(undefined),
 	theme: {
 		css: null,
-		id: signalObj<Theme | null>(null),
+		preference: signalObj<Theme | null>(null),
+		id: signalObj<ResolvedTheme | null>(null),
 	}
 };
 
@@ -177,10 +185,10 @@ function tryInject() {
 
 			const container = document.createElement('div')
 			container.id = 'nfe-container';
-			container.className = 'dark';
+			container.className = state.theme.id.get() === 'dark' ? 'theme-dark' : 'theme-light';
 			shadow.appendChild(container);
 
-			render(() => <QuoteWidget siteId={state.siteId ?? null} theme={state.theme.id.get} widgetStyle={state.widgetStyle.get} />, container);
+			render(() => <QuoteWidget siteId={state.siteId ?? null} themePreference={state.theme.preference.get} widgetStyle={state.widgetStyle.get} widgetAppearance={state.widgetAppearance.get} />, container);
 
 			nfeElement.style.display = isRegionBlockActive(region) ? 'block' : 'none';
 
@@ -311,6 +319,33 @@ const patchState = (regions: DesiredRegionState[]) => {
 
 const isRegionBlockActive = (region: RegionState) => region.enabled && !isSnoozing()
 
+const updateThemeInShadowRoots = () => {
+	for (const region of state.regions.values()) {
+		if (region.injectedThemeStyleElement != null) {
+			region.injectedThemeStyleElement.textContent = state.theme.css?.replace(':root', ':host') ?? '';
+		}
+
+		const container = region.shadow?.getElementById('nfe-container');
+		if (container != null) {
+			container.className = state.theme.id.get() === 'dark' ? 'theme-dark' : 'theme-light';
+		}
+	}
+}
+
+const applyTheme = (preference: Theme) => {
+	const resolved = resolveTheme(preference);
+	state.theme.preference.set(preference);
+	state.theme.id.set(resolved);
+	state.theme.css = themeCssForResolved(resolved, themeLight, themeDark);
+	updateThemeInShadowRoots();
+}
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+	if (state.theme.preference.get() === 'system') {
+		applyTheme('system');
+	}
+});
+
 browser.runtime.onMessage.addListener(async (msg: FromServiceWorkerMessage) => {
 	if (msg.type == 'nfe#siteDetails' && msg.token === token) {
 		if (msg.snoozeUntil != null && msg.snoozeUntil > Date.now()) {
@@ -321,10 +356,10 @@ browser.runtime.onMessage.addListener(async (msg: FromServiceWorkerMessage) => {
 
 		state.ready = true;
 		state.siteId = msg.siteId;
-		state.theme.css = msg.theme.css;
 		state.hideQuotes = msg.hideQuotes;
 		state.widgetStyle.set(msg.widgetStyle);
-		state.theme.id.set(msg.theme.id);
+		state.widgetAppearance.set(msg.widgetAppearance);
+		applyTheme(msg.theme.preference);
 
 		domReady.then(() => {
 			patchState(msg.regions);

--- a/src/entrypoints/service-worker/service-worker.ts
+++ b/src/entrypoints/service-worker/service-worker.ts
@@ -1,5 +1,5 @@
 import { getBrowser, type MessageSender, type TabId } from '/lib/webextension';
-import type { Path, PathList, Region, Site, SiteId } from '/types/sitelist';
+import type { Path, PathList, PathQuery, Region, Site, SiteId } from '/types/sitelist';
 import type { DesiredRegionState, RequestQuoteResponse, FromServiceWorkerMessage, ToServiceWorkerMessage } from '/messaging/messages';
 import { loadHideQuotes, loadQuoteLists, loadRegionHideStyle, loadRegionsForSite, loadSitelist, loadSnoozeUntil, loadWidgetStyle, migrationPromise, saveQuoteEnabled, saveSiteEnabled, saveSnoozeUntil, saveThemeForSite } from '/storage/storage';
 import { originsForSite } from '/lib/util';
@@ -47,29 +47,73 @@ const notifyTabsOptionsUpdated = async () => {
 	}
 }
 
-const pathPatternMatches = (path: string, pattern: Path): boolean => {
-	if (typeof pattern === 'string') {
-		return pattern === path;
-	} else if ('regexp' in pattern) {
-		return new RegExp(pattern.regexp).test(path);
+const searchParamMatches = (search: string, query: PathQuery): boolean => {
+	const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+
+	if (typeof query === 'string') {
+		const separatorIndex = query.indexOf('=');
+		if (separatorIndex === -1) {
+			return params.has(query);
+		}
+
+		const key = query.slice(0, separatorIndex);
+		const value = query.slice(separatorIndex + 1);
+		return params.get(key) === value;
 	}
+
+	return new RegExp(query.regexp).test(search);
+}
+
+const searchQueryMatches = (search: string, query: PathQuery | PathQuery[]): boolean => {
+	if (Array.isArray(query)) {
+		return query.every(part => searchParamMatches(search, part));
+	}
+
+	return searchParamMatches(search, query);
+}
+
+const pathPatternMatches = (pathname: string, search: string, pattern: Path): boolean => {
+	if (typeof pattern === 'string') {
+		return pattern === pathname;
+	}
+
+	if ('pathname' in pattern) {
+		if (pattern.pathname !== pathname) {
+			return false;
+		}
+
+		if (pattern.excludeSearch != null && searchQueryMatches(search, pattern.excludeSearch)) {
+			return false;
+		}
+
+		if (pattern.search == null) {
+			return true;
+		}
+
+		return searchQueryMatches(search, pattern.search);
+	}
+
+	if ('regexp' in pattern) {
+		return new RegExp(pattern.regexp).test(pathname);
+	}
+
 	return false;
 }
 
-const pathInPathList = (path: string, pathlist: PathList): boolean => {
-	return pathlist.find(pattern => pathPatternMatches(path, pattern)) != null;
+const pathInPathList = (pathname: string, search: string, pathlist: PathList): boolean => {
+	return pathlist.find(pattern => pathPatternMatches(pathname, search, pattern)) != null;
 }
 
-const isEnabledPath = (site: Site, region: Region, path: string): boolean | undefined => {
+const isEnabledPath = (site: Site, region: Region, pathname: string, search: string): boolean | undefined => {
 	if (region.paths === '*') {
 		return true;
 	}
 
 	if (region.paths === 'inherit') {
-		return pathInPathList(path, site.paths);
+		return pathInPathList(pathname, search, site.paths);
 	}
 
-	return pathInPathList(path, region.paths);
+	return pathInPathList(pathname, search, region.paths);
 }
 
 const cssForType = (type: Region['type'], hideStyle: StorageLocalV2['regionHideStyle']): string => {
@@ -165,7 +209,7 @@ const handleMessage = async (msg: ToServiceWorkerMessage, sender: MessageSender)
 
 			let regions = site.regions
 				.map((region): DesiredRegionState => {
-					if (isSnoozing || !isEnabledPath(site, region, msg.path)) {
+					if (isSnoozing || !isEnabledPath(site, region, msg.path, msg.search)) {
 						return { config: region, css: null, enabled: false };
 					}
 

--- a/src/entrypoints/service-worker/service-worker.ts
+++ b/src/entrypoints/service-worker/service-worker.ts
@@ -5,6 +5,7 @@ import { loadHideQuotes, loadQuoteLists, loadRegionHideStyle, loadRegionsForSite
 import { originsForSite } from '/lib/util';
 import { BuiltinQuotes, type Quote } from '/quote';
 import type { QuoteListId, StorageLocalV2, Theme } from '/storage/schema';
+import { themeCssForResolved } from '/lib/theme';
 import themeDark from '/themes/dark.css?raw';
 import themeLight from '/themes/light.css?raw';
 
@@ -219,7 +220,8 @@ const handleMessage = async (msg: ToServiceWorkerMessage, sender: MessageSender)
 					return { config: region, css: `${selector} { ${cssForType(region.type, regionHideStyle)} }`, enabled } ;
 				});
 
-			const theme = siteOptions.theme ?? 'light';
+			const themePreference = siteOptions.theme ?? 'system';
+			const themeResolved = themePreference === 'system' ? 'light' : themePreference;
 
 			sendMessage(sender.tab.id, {
 				type: 'nfe#siteDetails',
@@ -228,10 +230,12 @@ const handleMessage = async (msg: ToServiceWorkerMessage, sender: MessageSender)
 				snoozeUntil: snoozeUntil ?? null,
 				siteId: site.id,
 				widgetStyle,
+				widgetAppearance: site.widgetAppearance,
 				hideQuotes,
 				theme: {
-					css: theme === 'light' ? themeLight : themeDark,
-					id: theme,
+					preference: themePreference,
+					resolved: themeResolved,
+					css: themeCssForResolved(themeResolved, themeLight, themeDark),
 				}
 			})
 		}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,16 @@
+import type { ResolvedTheme, Theme } from '../storage/schema';
+
+export const resolveTheme = (preference: Theme | undefined): ResolvedTheme => {
+	if (preference === 'light' || preference === 'dark') {
+		return preference;
+	}
+
+	if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+		return 'dark';
+	}
+
+	return 'light';
+};
+
+export const themeCssForResolved = (resolved: ResolvedTheme, themeLight: string, themeDark: string) =>
+	resolved === 'light' ? themeLight : themeDark;

--- a/src/messaging/messages.ts
+++ b/src/messaging/messages.ts
@@ -1,6 +1,6 @@
 import { getBrowser } from "/lib/webextension";
-import type { QuoteListId, Theme } from "/storage/schema";
-import type { Region, SiteId } from "/types/sitelist";
+import type { QuoteListId, ResolvedTheme, Theme } from "/storage/schema";
+import type { Region, SiteId, WidgetAppearance } from "/types/sitelist";
 
 export const sendToServiceWorker = async <Response = any>(msg: ToServiceWorkerMessage): Promise<Response> => {
 	const browser = getBrowser();
@@ -18,10 +18,12 @@ type SiteDetails = {
 	siteId: SiteId,
 	regions: DesiredRegionState[],
 	theme: {
-		id: Theme,
+		preference: Theme,
+		resolved: ResolvedTheme,
 		css: string,
 	}
 	widgetStyle: 'contained' | 'transparent',
+	widgetAppearance?: WidgetAppearance,
 	snoozeUntil: number | null,
 	hideQuotes: boolean,
 }

--- a/src/messaging/messages.ts
+++ b/src/messaging/messages.ts
@@ -45,6 +45,7 @@ export type ToServiceWorkerMessage = RequestSiteDetails | OpenOptionsPage | Noti
 type RequestSiteDetails = {
 	type: 'requestSiteDetails',
 	path: string,
+	search: string,
 	token: number
 };
 

--- a/src/shared/quote-widget.tsx
+++ b/src/shared/quote-widget.tsx
@@ -1,7 +1,7 @@
 import { createResource, Show, type Accessor } from "solid-js"
 import { type RequestQuoteResponse, sendToServiceWorker } from "../messaging/messages"
 import type { Theme } from "../storage/schema";
-import type { SiteId } from "../types/sitelist";
+import type { SiteId, WidgetAppearance } from "../types/sitelist";
 import { createSignal } from "solid-js";
 import { loadHideWidgetToolbar, saveHideWidgetToolbar } from "/storage/storage";
 
@@ -11,16 +11,15 @@ const [quote, { refetch: refetchQuote }] = createResource(async () => {
 	});
 })
 
-const toggleTheme = async (e: { preventDefault: () => void }, siteId: SiteId, theme: Theme) => {
-	e.preventDefault();
+const setTheme = async (siteId: SiteId, theme: Theme) => {
 	await sendToServiceWorker({
 		type: 'setSiteTheme',
 		siteId,
-		theme: theme === 'light' ? 'dark' : 'light',
+		theme,
 	})
 }
 
-export const QuoteWidget = ({ siteId, theme, widgetStyle }: { siteId: SiteId | null, theme: Accessor<Theme | null>, widgetStyle: Accessor<'contained' | 'transparent'> }) => {
+export const QuoteWidget = ({ siteId, themePreference, widgetStyle, widgetAppearance }: { siteId: SiteId | null, themePreference: Accessor<Theme | null>, widgetStyle: Accessor<'contained' | 'transparent'>, widgetAppearance: Accessor<WidgetAppearance | undefined> }) => {
 	const [collapsed, setCollapsedLocal] = createSignal(true);
 
 	// Quote must be enabled if it appears in here
@@ -54,9 +53,17 @@ export const QuoteWidget = ({ siteId, theme, widgetStyle }: { siteId: SiteId | n
 
 	const openOptionsPage = () => sendToServiceWorker({ type: 'openOptionsPage' })
 
+	const isFacebook = () => widgetAppearance() === 'facebook';
+	const containedClasses = () => {
+		if (widgetStyle() !== 'contained') return '';
+		return isFacebook()
+			? 'bg-widget-ground shadow widget-facebook'
+			: 'bg-widget-ground b-1 shadow rounded';
+	};
+
 	return <aside class="space-y-2">
 		<Show when={quote()}>
-			<div class={`${widgetStyle() === 'contained' ? 'bg-widget-ground b-1 shadow rounded' : ''} font-md`}>
+			<div class={`font-md ${isFacebook() ? 'rounded-lg overflow-hidden' : ''} ${containedClasses()}`}>
 				<div class="w-full position-relative">
 					<Show when={collapsed()}>
 						<div class="p-2 flex w-full axis-end position-absolute lr-0 pointer-events-none">
@@ -66,10 +73,17 @@ export const QuoteWidget = ({ siteId, theme, widgetStyle }: { siteId: SiteId | n
 					<Show when={!collapsed()}>
 						<div class="p-2 bg-darken-100 space-x-4 flex w-full cross-center">
 							<Show when={siteId != null}>
-								<label for="theme-toggle" class="cursor-pointer text-primary gap-1 flex cross-center">
-									<span aria-label="Light mode">☀️</span>
-									<input id="theme-toggle" type="checkbox" checked={theme() === 'dark'} class="toggle" onInput={e => toggleTheme(e, siteId!, theme() ?? 'light')} />
-									<span aria-label="Dark mode">🌙</span>
+								<label for="theme-select" class="text-primary gap-1 flex cross-center font-sm">
+									<span>Theme</span>
+									<select
+										id="theme-select"
+										value={themePreference() ?? 'system'}
+										onChange={e => setTheme(siteId!, e.currentTarget.value as Theme)}
+									>
+										<option value="light">Light</option>
+										<option value="dark">Dark</option>
+										<option value="system">System</option>
+									</select>
 								</label>
 							</Show>
 							<div class="flex-1" />

--- a/src/shared/styles.css
+++ b/src/shared/styles.css
@@ -84,6 +84,24 @@ button.tertiary:hover, .buttonlike.tertiary:hover {
 button.tertiary.bg-transparent { background-color: transparent; }
 button.tertiary.bg-transparent:hover { background-color: var(--theme-tertiary-button-hover-bg); }
 
+select {
+	border: 1px solid var(--theme-border);
+	border-radius: 4px;
+	background-color: var(--theme-tertiary-button-bg);
+	color: var(--theme-text-primary);
+	padding: 0.25em 0.5em;
+	cursor: pointer;
+}
+
+select:hover {
+	background-color: var(--theme-tertiary-button-hover-bg);
+}
+
+select:focus {
+	outline: none;
+	box-shadow: 0 0 0 0.2em var(--theme-accent-a500);
+}
+
 .overlay-container { position: relative; isolation: isolate; }
 .overlay-container > .overlay { position: absolute; top: 0; left: 0; right: 0; bottom: 0; }
 
@@ -162,6 +180,7 @@ button.tertiary.bg-transparent:hover { background-color: var(--theme-tertiary-bu
 .opacity-0 { opacity: 0; }
 
 .rounded { border-radius: 4px; }
+.rounded-lg { border-radius: 8px; }
 
 .flex { display: flex; }
 .flex-1 { flex: 1; }
@@ -176,6 +195,14 @@ button.tertiary.bg-transparent:hover { background-color: var(--theme-tertiary-bu
 
 .shadow { box-shadow: var(--theme-shadow); }
 
+.widget-facebook {
+	--theme-shadow: rgba(0, 0, 0, 0.2) 0px 1px 2px 0px;
+}
+
+.theme-dark .widget-facebook {
+	--theme-widget-ground: #2A2B2C;
+}
+
 .card { background-color: var(--theme-lighten-100); }
 .card.secondary { background-color: var(--theme-accent-a200); }
 .card.primary { background-color: var(--theme-accent-a500); }
@@ -187,6 +214,7 @@ button.tertiary.bg-transparent:hover { background-color: var(--theme-tertiary-bu
 }
 
 .overflow-x-hidden { overflow-x: hidden; }
+.overflow-hidden { overflow: hidden; }
 
 .w-full { width: 100%; }
 .lr-0 { left: 0; right: 0; }

--- a/src/sitelist/facebook.ts
+++ b/src/sitelist/facebook.ts
@@ -5,6 +5,7 @@ export const site: Site = {
 	title: 'Facebook',
 	hosts: ['www.facebook.com', 'web.facebook.com'],
 	paths: ['/'],
+	widgetAppearance: 'facebook',
 	regions: [
 		{
 			id: regionId('main-feed'),

--- a/src/sitelist/facebook.ts
+++ b/src/sitelist/facebook.ts
@@ -10,7 +10,7 @@ export const site: Site = {
 			id: regionId('main-feed'),
 			title: 'Main feed',
 			type: 'hide',
-			paths: 'inherit',
+			paths: [{ pathname: '/', excludeSearch: ['filter=groups', 'sk=h_chr'] }],
 			selectors: ['div.x1hc1fzr.x1unhpq9.x6o7n8i'],
 			inject: {
 				mode: 'before',
@@ -30,6 +30,17 @@ export const site: Site = {
 			default: false,
 			paths: ['/groups/feed/'],
 			selectors: ['div[role="feed"]'],
+			inject: {
+				mode: 'before',
+			}
+		},
+		{
+			id: regionId('chronological-groups-feed'),
+			title: 'Chronological groups feed',
+			type: 'hide',
+			default: false,
+			paths: [{ pathname: '/', search: ['filter=groups', 'sk=h_chr'] }],
+			selectors: ['div.x1hc1fzr.x1unhpq9.x6o7n8i'],
 			inject: {
 				mode: 'before',
 			}

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -58,7 +58,8 @@ export const defaultQuoteLists = (): QuoteList[] => [
 	}
 ];
 
-export type Theme = 'light' | 'dark';
+export type Theme = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
 
 export type StorageLocal = StorageLocalV2;
 

--- a/src/types/sitelist.ts
+++ b/src/types/sitelist.ts
@@ -13,12 +13,15 @@ export type PathQuery = string | { regexp: string };
 export type Path = string | { regexp: string } | { pathname: string, search?: PathQuery | PathQuery[], excludeSearch?: PathQuery | PathQuery[] };
 export type PathList = Path[];
 
+export type WidgetAppearance = 'facebook';
+
 export type Site = {
 	id: SiteId,
 	title: string,
 	hosts: string[],
 	paths: PathList,
 	popular?: boolean,
+	widgetAppearance?: WidgetAppearance,
 	regions: Region[]
 };
 

--- a/src/types/sitelist.ts
+++ b/src/types/sitelist.ts
@@ -9,7 +9,8 @@ export type RegionId = string & { __sectionId: never };
 export const siteId = (id: string): SiteId => id as SiteId;
 export const regionId = (id: string): RegionId => id as RegionId;
 
-export type Path = string | { regexp: string };
+export type PathQuery = string | { regexp: string };
+export type Path = string | { regexp: string } | { pathname: string, search?: PathQuery | PathQuery[], excludeSearch?: PathQuery | PathQuery[] };
 export type PathList = Path[];
 
 export type Site = {


### PR DESCRIPTION
This addresses #566 to exclude the chronological groups feed (https://www.facebook.com/?filter=groups&sk=h_chr) from the "Main feed" block, and this feed its own toggle.