### PR TITLE
Block m.facebook.com news feed

### DIFF
--- a/src/sitelist/facebook.ts
+++ b/src/sitelist/facebook.ts
@@ -3,7 +3,7 @@ import { regionId, siteId, type Site } from "../types/sitelist";
 export const site: Site = {
 	id: siteId('facebook'),
 	title: 'Facebook',
-	hosts: ['www.facebook.com', 'web.facebook.com'],
+	hosts: ['www.facebook.com', 'web.facebook.com', 'm.facebook.com'],
 	paths: ['/', '/home.php'],
 	regions: [
 		{
@@ -11,7 +11,7 @@ export const site: Site = {
 			title: 'Main feed',
 			type: 'hide',
 			paths: 'inherit',
-			selectors: ['div.x1hc1fzr.x1unhpq9.x6o7n8i'],
+			selectors: ['div.x1hc1fzr.x1unhpq9.x6o7n8i', '[data-dcm-id]'],
 			inject: {
 				mode: 'before',
 			}


### PR DESCRIPTION
Confirmed working on Firefox for Android with custom build signed via Firefox add ons site.

The added selector targets all news feed items. It does not target the transparent dividers between news feed items, but who cares.

## Hidden

- News Feed

## Still working

- Marketplace
- Groups

<img width="400" alt="d7f5e1e8-c09f-4029-9374-89e6451557ed" src="https://github.com/user-attachments/assets/dc1d67c8-8ed7-45e4-be9c-d158aadc9236" />
